### PR TITLE
Fix/read state and v4 polling

### DIFF
--- a/src/icp_canister/canister.py
+++ b/src/icp_canister/canister.py
@@ -169,6 +169,7 @@ class Canister:
             # verify_certificate is a control parameter for agent.update(), not a method argument
             # Default to True to match Agent.update() default behavior for security
             verify_certificate = kwargs.pop('verify_certificate', True)
+            timeout = kwargs.pop('timeout', None)
             
             # 3. Handle kwargs: if kwargs are provided and no args, convert kwargs to a single record argument
             # This allows calling methods like: method(field1=val1, field2=val2) for single-record methods
@@ -200,20 +201,30 @@ class Canister:
             # 7. Execute network request using Agent's high-level query/update methods
             # These methods automatically encode args and decode return values
             if is_query:
+                query_kwargs = dict(
+                    arg=processed_args if processed_args else None,
+                    return_type=ret_types,
+                )
+                if timeout is not None:
+                    query_kwargs['timeout'] = timeout
                 res = self.agent.query(
                     self.canister_id,
                     name,
-                    arg=processed_args if processed_args else None,
-                    return_type=ret_types
+                    **query_kwargs,
                 )
             else:
                 # verify_certificate was already extracted in step 2
+                update_kwargs = dict(
+                    arg=processed_args if processed_args else None,
+                    return_type=ret_types,
+                    verify_certificate=verify_certificate,
+                )
+                if timeout is not None:
+                    update_kwargs['timeout'] = timeout
                 res = self.agent.update(
                     self.canister_id,
                     name,
-                    arg=processed_args if processed_args else None,
-                    return_type=ret_types,
-                    verify_certificate=verify_certificate
+                    **update_kwargs,
                 )
             
             # 7. Return the result (already decoded by query/update methods)
@@ -230,6 +241,7 @@ class Canister:
             arg_types = method_type.argTypes
             ret_types = method_type.retTypes
             verify_certificate = kwargs.pop('verify_certificate', True)
+            timeout = kwargs.pop('timeout', None)
 
             if kwargs and not args and len(arg_types) == 1:
                 args = (kwargs,)
@@ -250,19 +262,29 @@ class Canister:
             is_query = 'query' in annotations
 
             if is_query:
+                query_kwargs = dict(
+                    arg=processed_args if processed_args else None,
+                    return_type=ret_types,
+                )
+                if timeout is not None:
+                    query_kwargs['timeout'] = timeout
                 res = await self.agent.query_async(
                     self.canister_id,
                     name,
-                    arg=processed_args if processed_args else None,
-                    return_type=ret_types
+                    **query_kwargs,
                 )
             else:
+                update_kwargs = dict(
+                    arg=processed_args if processed_args else None,
+                    return_type=ret_types,
+                    verify_certificate=verify_certificate,
+                )
+                if timeout is not None:
+                    update_kwargs['timeout'] = timeout
                 res = await self.agent.update_async(
                     self.canister_id,
                     name,
-                    arg=processed_args if processed_args else None,
-                    return_type=ret_types,
-                    verify_certificate=verify_certificate
+                    **update_kwargs,
                 )
 
             return res

--- a/tests/test_bugfixes.py
+++ b/tests/test_bugfixes.py
@@ -1,0 +1,267 @@
+"""
+Unit tests for three bugfixes:
+
+1. read_state_raw must NOT include canister_id in the signed content map.
+   (IC spec: canister_id is only in the URL path for routing.)
+
+2. update_raw must fall back to poll_and_wait when the v4 /call endpoint
+   returns HTTP 202 with a non-CBOR body (canister took too long for
+   synchronous reply).
+
+3. Canister wrapper must pass through the `timeout` kwarg to Agent methods.
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock, PropertyMock
+import cbor2
+import httpx
+
+from icp_agent.agent import Agent, sign_request
+from icp_agent.client import Client
+from icp_identity.identity import Identity
+
+# Ed25519 test vector (RFC 8032); used only for tests, not a real secret.
+TEST_PRIVKEY_HEX = "833fe62409237b9d62ec77587520911e9a759cec1d19755b7da901b96dca3d42"
+CANISTER_ID = "wcrzb-2qaaa-aaaap-qhpgq-cai"
+
+
+@pytest.fixture
+def agent():
+    client = Client(url="https://ic0.app")
+    iden = Identity(privkey=TEST_PRIVKEY_HEX)
+    return Agent(iden, client)
+
+
+# ---------------------------------------------------------------------------
+# Fix 1: read_state_raw must NOT include canister_id in signed content
+# ---------------------------------------------------------------------------
+
+class TestReadStateNoCanisterId:
+    """
+    The IC spec says the read_state request content map contains:
+        request_type, sender, paths, ingress_expiry
+    It does NOT include canister_id.  Including it changes the
+    representation-independent hash, causing signature verification
+    failures on the boundary node (especially with secp256k1 identities).
+    """
+
+    def test_read_state_request_has_no_canister_id(self, agent):
+        """Verify the request dict built by read_state_raw omits canister_id."""
+        captured_req = {}
+
+        original_sign = sign_request
+
+        def spy_sign_request(req, iden):
+            captured_req.update(req)
+            return original_sign(req, iden)
+
+        # Mock read_state_endpoint to avoid network call, and spy on sign_request
+        with patch.object(agent, 'read_state_endpoint', return_value=b'') as mock_ep, \
+             patch('icp_agent.agent.sign_request', side_effect=spy_sign_request):
+            # read_state_raw will fail when trying to cbor2.loads(b''), but
+            # we only care about the request dict passed to sign_request.
+            try:
+                agent.read_state_raw(CANISTER_ID, [[b"time"]])
+            except Exception:
+                pass  # Expected — we didn't return valid CBOR
+
+        assert "canister_id" not in captured_req, \
+            "read_state_raw must NOT include canister_id in the signed content map"
+        assert captured_req["request_type"] == "read_state"
+        assert "sender" in captured_req
+        assert "paths" in captured_req
+        assert "ingress_expiry" in captured_req
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: update_raw falls back to poll_and_wait on non-CBOR 202
+# ---------------------------------------------------------------------------
+
+class TestUpdateRawV4Fallback:
+    """
+    The v4 /call endpoint returns a synchronous CBOR response if the canister
+    replies within ~10s.  If the canister takes longer, the boundary node
+    returns HTTP 202 with a non-CBOR body (e.g. plain text request_id).
+    update_raw must detect this and fall back to poll_and_wait.
+    """
+
+    def test_non_cbor_202_triggers_polling(self, agent):
+        """HTTP 202 with non-CBOR body must trigger poll_and_wait."""
+        mock_http_resp = MagicMock(spec=httpx.Response)
+        mock_http_resp.status_code = 202
+        mock_http_resp.content = b"not-cbor-data"
+
+        with patch.object(agent, 'call_endpoint', return_value=mock_http_resp), \
+             patch.object(agent, 'poll_and_wait', return_value=b"poll_result") as mock_poll:
+            result = agent.update_raw(
+                CANISTER_ID, "some_method", b"",
+                verify_certificate=False,
+            )
+
+        mock_poll.assert_called_once()
+        assert result == b"poll_result"
+
+    def test_non_cbor_non_202_raises(self, agent):
+        """HTTP 500 with non-CBOR body must raise RuntimeError (not poll)."""
+        mock_http_resp = MagicMock(spec=httpx.Response)
+        mock_http_resp.status_code = 500
+        mock_http_resp.content = b"Internal Server Error"
+
+        with patch.object(agent, 'call_endpoint', return_value=mock_http_resp), \
+             patch.object(agent, 'poll_and_wait') as mock_poll:
+            with pytest.raises(RuntimeError, match="non-CBOR body"):
+                agent.update_raw(
+                    CANISTER_ID, "some_method", b"",
+                    verify_certificate=False,
+                )
+
+        mock_poll.assert_not_called()
+
+    def test_valid_cbor_replied_does_not_poll(self, agent):
+        """Valid CBOR 'replied' response must be handled directly, not polled."""
+        # Build a minimal CBOR response with status=replied and a certificate
+        # We'll mock the Certificate to avoid needing real crypto
+        fake_cert_cbor = cbor2.dumps({"tree": [0]})
+        response_obj = {
+            "status": "replied",
+            "certificate": fake_cert_cbor,
+        }
+        mock_http_resp = MagicMock(spec=httpx.Response)
+        mock_http_resp.status_code = 200
+        mock_http_resp.content = cbor2.dumps(response_obj)
+
+        with patch.object(agent, 'call_endpoint', return_value=mock_http_resp), \
+             patch.object(agent, 'poll_and_wait') as mock_poll, \
+             patch('icp_agent.agent.Certificate') as MockCert:
+            # Set up the mock certificate
+            cert_instance = MockCert.return_value
+            cert_instance.lookup_request_status.return_value = "replied"
+            cert_instance.lookup_reply.return_value = b"\x44\x49\x44\x4c\x00\x00"  # DIDL empty
+
+            result = agent.update_raw(
+                CANISTER_ID, "some_method", b"",
+                verify_certificate=False,
+            )
+
+        mock_poll.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Fix 3: Canister wrapper passes timeout through to Agent methods
+# ---------------------------------------------------------------------------
+
+class TestCanisterTimeoutPassthrough:
+    """
+    The Canister wrapper's _create_method extracts `timeout` from kwargs
+    and passes it to agent.query() or agent.update().  Previously, timeout
+    was silently dropped.
+    """
+
+    def test_query_method_passes_timeout(self):
+        """timeout kwarg must be forwarded to agent.query()."""
+        from icp_canister.canister import Canister
+
+        mock_agent = MagicMock()
+        mock_agent.query.return_value = [42]
+
+        # Create a minimal FuncClass-like object
+        func = MagicMock()
+        func.argTypes = []
+        func.retTypes = []
+        func.annotations = ["query"]
+
+        canister = Canister.__new__(Canister)
+        canister.agent = mock_agent
+        canister.canister_id = CANISTER_ID
+        canister.methods = {}
+        canister.actor = None
+        canister.init_args = []
+
+        # Use the internal method to create a bound method
+        method = canister._create_method("greet", func)
+        method(timeout=120)
+
+        # Verify timeout was passed through
+        mock_agent.query.assert_called_once()
+        call_kwargs = mock_agent.query.call_args[1]
+        assert call_kwargs.get("timeout") == 120
+
+    def test_update_method_passes_timeout(self):
+        """timeout kwarg must be forwarded to agent.update()."""
+        from icp_canister.canister import Canister
+
+        mock_agent = MagicMock()
+        mock_agent.update.return_value = [0]
+
+        func = MagicMock()
+        func.argTypes = []
+        func.retTypes = []
+        func.annotations = []  # no 'query' → update call
+
+        canister = Canister.__new__(Canister)
+        canister.agent = mock_agent
+        canister.canister_id = CANISTER_ID
+        canister.methods = {}
+        canister.actor = None
+        canister.init_args = []
+
+        method = canister._create_method("do_something", func)
+        method(timeout=300)
+
+        mock_agent.update.assert_called_once()
+        call_kwargs = mock_agent.update.call_args[1]
+        assert call_kwargs.get("timeout") == 300
+
+    def test_no_timeout_kwarg_omits_timeout(self):
+        """When timeout is not passed, it must NOT appear in agent call kwargs."""
+        from icp_canister.canister import Canister
+
+        mock_agent = MagicMock()
+        mock_agent.query.return_value = [42]
+
+        func = MagicMock()
+        func.argTypes = []
+        func.retTypes = []
+        func.annotations = ["query"]
+
+        canister = Canister.__new__(Canister)
+        canister.agent = mock_agent
+        canister.canister_id = CANISTER_ID
+        canister.methods = {}
+        canister.actor = None
+        canister.init_args = []
+
+        method = canister._create_method("greet", func)
+        method()
+
+        mock_agent.query.assert_called_once()
+        call_kwargs = mock_agent.query.call_args[1]
+        assert "timeout" not in call_kwargs, \
+            "timeout must be omitted when not explicitly provided"
+
+    def test_verify_certificate_still_works(self):
+        """verify_certificate kwarg must still be forwarded to agent.update()."""
+        from icp_canister.canister import Canister
+
+        mock_agent = MagicMock()
+        mock_agent.update.return_value = [0]
+
+        func = MagicMock()
+        func.argTypes = []
+        func.retTypes = []
+        func.annotations = []
+
+        canister = Canister.__new__(Canister)
+        canister.agent = mock_agent
+        canister.canister_id = CANISTER_ID
+        canister.methods = {}
+        canister.actor = None
+        canister.init_args = []
+
+        method = canister._create_method("do_something", func)
+        method(verify_certificate=False, timeout=60)
+
+        mock_agent.update.assert_called_once()
+        call_kwargs = mock_agent.update.call_args[1]
+        assert call_kwargs.get("verify_certificate") is False
+        assert call_kwargs.get("timeout") == 60


### PR DESCRIPTION
# Summary                                                                                                      
                                                                                                               
  While integrating icp-py-core into https://github.com/onicai/IConfucius (an AI application on the Internet   
  Computer), we discovered three bugs when using secp256k1 identities with long-running update calls (>10s     
  canister execution time). These fixes are against the  feature/verify-replica-query-signature-and-canister-timeout branch.                                          
                                                                                                               
# Context                                                                                                      
                                                                                                               
  IConfucius uses an on-chain LLM canister call that takes 15-30 seconds. When calling this via   
  icp-py-core's Canister wrapper with a secp256k1 identity, three issues surfaced in sequence:                 
                                                                                                               
  1. The v4 /call endpoint returned HTTP 202 with a non-CBOR body (the boundary node's timeout was ~10s), but  
  update_raw tried to CBOR-decode it and crashed                                                               
  2. After fixing that, polling via read_state failed with 400 "Invalid signature: EcdsaSecp256k1 signature    
  could not be verified"                                                                                       
  3. The Canister wrapper silently dropped timeout kwargs, making it impossible to configure poll timeouts for 
  long-running calls                                                                                           
                                                                                                               
 # Fixes                                                                                                        
                                                                                                               
  - read_state_raw / read_state_raw_async: Remove canister_id from signed content map                          
  Per the https://internetcomputer.org/docs/references/ic-interface-spec#http-read-state, the read_state       
  request content map contains request_type, sender, paths, and ingress_expiry — but NOT canister_id. The      
  canister_id is only in the URL path for routing. Including it in the content changed the                     
  representation-independent hash (request_id), causing signature verification failures on the boundary node.  
  This bug was particularly visible with secp256k1 identities.                                                 
  - update_raw: Fall back to poll_and_wait on HTTP 202 with non-CBOR body                                      
  The v4 /call endpoint returns a synchronous CBOR response if the canister replies within ~10s. If the        
  canister takes longer, the boundary node returns HTTP 202 with a non-CBOR body. Previously, update_raw       
  crashed with "Malformed update response". Now it detects non-CBOR responses on 202 and falls through to      
  poll_and_wait.                                                                                               
  - Canister._create_method / _create_async_method: Pass timeout kwarg through                                 
  The Canister wrapper extracted verify_certificate from kwargs but silently dropped all other control         
  parameters including timeout. Now timeout is extracted and forwarded to agent.query() / agent.update().      
                                                                                                               
  # Test plan                                                                                                    
                                                                                                               
  - 8 new unit tests in tests/test_bugfixes.py (no network required):                                          
    - read_state_raw omits canister_id from signed content                                                     
    - HTTP 202 non-CBOR triggers poll_and_wait                                                                 
    - HTTP 500 non-CBOR raises RuntimeError                                                                    
    - Valid CBOR "replied" response handled directly (no polling)                                              
    - timeout forwarded to agent.query() and agent.update()                                                    
    - Missing timeout omitted from agent call kwargs                                                           
    - verify_certificate + timeout work together                                                               
  - All existing tests still pass (78 passed, 5 skipped — 18 pre-existing failures in                          
  test_vart_service_reference.py unrelated)                                                                    
  - End-to-end verified: IConfucius IConfuciusSays update call (15-30s execution) succeeds with secp256k1      
  identity via icp-py-core  