### PR TITLE
fix: security & correctness fixes from src audit

### DIFF
--- a/src/icp_agent/agent.py
+++ b/src/icp_agent/agent.py
@@ -340,8 +340,8 @@ def verify_ed25519_signature(signature: bytes, message: bytes, public_key: bytes
 def extract_ed25519_pubkey_from_der(der_key: bytes) -> bytes:
     """
     Extract Ed25519 public key from DER-encoded node public key.
-    
-    Node public keys are DER-encoded BLS keys (44 bytes):
+
+    Node public keys are DER-encoded Ed25519 keys (44 bytes, RFC 8410):
     - 12-byte DER prefix: [48, 42, 48, 5, 6, 3, 43, 101, 112, 3, 33, 0]
     - 32-byte Ed25519 public key
     
@@ -559,14 +559,19 @@ class Agent:
             raise ValueError(f"Invalid subnet_id format: {subnet_id.hex()}") from e
         
         path = [b"subnet", subnet_id, b"node", node_id, b"public_key"]
-        # Skip BLS verification when fetching node keys for query signature verification
-        # The node key itself will be verified during signature verification
-        certificate = self.read_state_subnet_raw(subnet_id_str, [path], verify_certificate=False)
+        # The node key is the trust anchor for query-signature verification, so it
+        # MUST come from a BLS-verified subnet certificate. Reading it without
+        # verification would let a malicious boundary node supply a forged node
+        # key (and a matching forged signature), defeating the whole purpose of
+        # query-signature verification. verify_certificate=True is fail-closed:
+        # it raises (e.g. BlstUnavailable / SignatureVerificationFailed) rather
+        # than trusting unverified data.
+        certificate = self.read_state_subnet_raw(subnet_id_str, [path], verify_certificate=True)
         public_key = certificate.lookup(path)
-        
+
         if public_key is None:
             raise NodeKeyNotFoundError(node_id, subnet_id)
-        
+
         # Cache the key
         self.node_key_cache.set(subnet_id, node_id, public_key)
         return public_key
@@ -587,14 +592,14 @@ class Agent:
             raise ValueError(f"Invalid subnet_id format: {subnet_id.hex()}") from e
         
         path = [b"subnet", subnet_id, b"node", node_id, b"public_key"]
-        # Skip BLS verification when fetching node keys for query signature verification
-        # The node key itself will be verified during signature verification
-        certificate = await self.read_state_subnet_raw_async(subnet_id_str, [path], verify_certificate=False)
+        # The node key is the trust anchor for query-signature verification, so it
+        # MUST come from a BLS-verified subnet certificate (see the sync variant).
+        certificate = await self.read_state_subnet_raw_async(subnet_id_str, [path], verify_certificate=True)
         public_key = certificate.lookup(path)
-        
+
         if public_key is None:
             raise NodeKeyNotFoundError(node_id, subnet_id)
-        
+
         # Cache the key
         self.node_key_cache.set(subnet_id, node_id, public_key)
         return public_key
@@ -606,22 +611,25 @@ class Agent:
         Returns:
             Tuple of (subnet_id, empty_dict). Node keys are fetched on-demand during signature verification.
         """
-        # Read canister state to get certificate with delegation
+        # Read canister state to get certificate with delegation.
+        # verify_certificate=True so the subnet_id comes from a BLS-verified
+        # delegation: otherwise an attacker could point us at a subnet whose
+        # node keys they control and have us "verify" their forged signature.
         paths = [[b"time"]]  # Minimal path to get certificate
-        cert = self.read_state_raw(canister_id, paths, verify_certificate=False)
-        
+        cert = self.read_state_raw(canister_id, paths, verify_certificate=True)
+
         # Determine subnet_id from delegation
         subnet_id = None
         if cert.delegation is not None:
             subnet_id_raw = cert.delegation.get("subnet_id") or cert.delegation.get(b"subnet_id")
             if subnet_id_raw is not None:
                 subnet_id = bytes(subnet_id_raw)
-        
+
         if subnet_id is None:
             # If no delegation, this might be NNS canister (root subnet)
             # For root subnet, subnet_id is derived from root key
             subnet_id = Principal.self_authenticating(self.root_key).bytes
-        
+
         # Return subnet_id and empty dict (node keys fetched on-demand)
         return subnet_id, {}
 
@@ -632,10 +640,12 @@ class Agent:
         Returns:
             Tuple of (subnet_id, empty_dict). Node keys are fetched on-demand during signature verification.
         """
-        # Read canister state to get certificate with delegation
+        # Read canister state to get certificate with delegation.
+        # verify_certificate=True so the subnet_id comes from a BLS-verified
+        # delegation (see the sync variant for the rationale).
         paths = [[b"time"]]  # Minimal path to get certificate
-        cert = await self.read_state_raw_async(canister_id, paths, verify_certificate=False)
-        
+        cert = await self.read_state_raw_async(canister_id, paths, verify_certificate=True)
+
         # Determine subnet_id from delegation
         subnet_id = None
         if cert.delegation is not None:

--- a/src/icp_agent/system_state.py
+++ b/src/icp_agent/system_state.py
@@ -8,13 +8,14 @@ import cbor2
 
 from icp_agent import Agent
 from icp_principal import Principal
-from icp_candid.candid import LEB128
 
 
 def time(agent: Agent, canister_id: str) -> int:
     certificate = agent.read_state_raw(canister_id, [["time".encode()]])
-    timestamp = certificate.lookup_time()
-    return LEB128.decode_u_bytes(bytes(timestamp))
+    # lookup_time() already decodes the ULEB128 'time' leaf into an int.
+    # Decoding it again (via bytes(int)) would allocate a multi-exabyte buffer
+    # and raise MemoryError, so just return the decoded value directly.
+    return certificate.lookup_time()
 
 def subnet_public_key(agent: Agent, canister_id: str, subnet_id: str) -> str:
     path = ["subnet".encode(), Principal.from_str(subnet_id).bytes, "public_key".encode()]

--- a/src/icp_identity/identity.py
+++ b/src/icp_identity/identity.py
@@ -267,10 +267,14 @@ class Identity:
         return self._der_pubkey
 
     def __repr__(self) -> str:
-        return f"Identity({self.key_type}, {self._privkey}, {self._pubkey})"
+        # Never include the private key: repr() routinely ends up in logs,
+        # tracebacks, and debuggers, and leaking key material there is a
+        # serious vulnerability. Only the (public) key type and public key
+        # are shown.
+        return f"Identity(type={self.key_type}, pubkey={self._pubkey}, privkey=<redacted>)"
 
     def __str__(self) -> str:
-        return f"({self.key_type}, {self._privkey}, {self._pubkey})"
+        return f"Identity(type={self.key_type}, pubkey={self._pubkey})"
 
 
 # =========================
@@ -347,7 +351,9 @@ class DelegateIdentity:
         return DelegateIdentity(inner, parsed_ic_delegation)
 
     def __repr__(self) -> str:
-        return f"DelegateIdentity(identity={self.identity!r}, delegations={self._delegations!r})"
+        # self.identity!r is now redacted (see Identity.__repr__); show only the
+        # delegation count rather than dumping the full chain.
+        return f"DelegateIdentity(identity={self.identity!r}, delegations={len(self._delegations)})"
 
     def __str__(self) -> str:
-        return f"(DelegateIdentity identity={self.identity}, delegations={self._delegations})"
+        return f"DelegateIdentity(pubkey={self._der_pubkey.hex()}, delegations={len(self._delegations)})"

--- a/tests/test_cbor2_frozendict_compat.py
+++ b/tests/test_cbor2_frozendict_compat.py
@@ -30,6 +30,11 @@ from icp_agent.agent import Agent
 from icp_agent.client import Client
 from icp_identity.identity import Identity
 
+# cbor2 exposes the immutable tagged-map class as ``FrozenDict`` (5.7–5.x)
+# and renamed it to ``frozendict`` in the 6.x Rust core. Resolve whichever
+# this install provides so these tests exercise the real decode type.
+FrozenDict = getattr(cbor2, "FrozenDict", None) or getattr(cbor2, "frozendict")
+
 # Ed25519 test vector (RFC 8032); used only for tests, not a real secret.
 TEST_PRIVKEY_HEX = "833fe62409237b9d62ec77587520911e9a759cec1d19755b7da901b96dca3d42"
 CANISTER_ID = "wcrzb-2qaaa-aaaap-qhpgq-cai"
@@ -50,13 +55,13 @@ class TestFrozenDictContract:
     """Confirm cbor2.FrozenDict is a Mapping but not a dict."""
 
     def test_frozendict_is_mapping_not_dict(self):
-        fd = cbor2.FrozenDict({"status": "replied"})
+        fd = FrozenDict({"status": "replied"})
         assert isinstance(fd, Mapping)
         # This is the exact mismatch that caused issue #14:
         assert not isinstance(fd, dict)
 
     def test_frozendict_supports_get_and_in(self):
-        fd = cbor2.FrozenDict({"status": "replied", "certificate": b"x"})
+        fd = FrozenDict({"status": "replied", "certificate": b"x"})
         assert fd["status"] == "replied"
         assert fd.get("status") == "replied"
         assert "status" in fd
@@ -83,7 +88,7 @@ class TestUpdateRawAcceptsFrozenDict:
     def test_replied_status_with_frozendict(self, agent):
         """status=replied wrapped in FrozenDict must not raise Malformed."""
         # Build the response body as a FrozenDict (what cbor2 6.x produces)
-        response_obj = cbor2.FrozenDict({
+        response_obj = FrozenDict({
             "status": "replied",
             "certificate": b"<cert-bytes>",
         })
@@ -111,7 +116,7 @@ class TestUpdateRawAcceptsFrozenDict:
         """status=non_replicated_rejection wrapped in FrozenDict must surface as ReplicaReject."""
         from icp_core.errors import ReplicaReject
 
-        response_obj = cbor2.FrozenDict({
+        response_obj = FrozenDict({
             "status": "non_replicated_rejection",
             "reject_code": 3,
             "reject_message": "method not found",
@@ -133,7 +138,7 @@ class TestUpdateRawAcceptsFrozenDict:
 
     def test_accepted_status_with_frozendict_polls(self, agent):
         """status=accepted wrapped in FrozenDict must trigger polling."""
-        response_obj = cbor2.FrozenDict({"status": "accepted"})
+        response_obj = FrozenDict({"status": "accepted"})
         mock_http_resp = self._make_response(202, response_obj)
 
         with patch.object(agent, "call_endpoint", return_value=mock_http_resp), \
@@ -162,9 +167,9 @@ class TestQueryRawAcceptsFrozenDict:
     def test_query_raw_replied_with_frozendict(self, agent):
         # Inner reply is itself a FrozenDict (nested tagged map under 6.x)
         reply_arg = b"DIDL\x00\x00"
-        result_obj = cbor2.FrozenDict({
+        result_obj = FrozenDict({
             "status": "replied",
-            "reply": cbor2.FrozenDict({"arg": reply_arg}),
+            "reply": FrozenDict({"arg": reply_arg}),
         })
 
         with patch.object(agent, "query_endpoint", return_value=result_obj):
@@ -179,7 +184,7 @@ class TestQueryRawAcceptsFrozenDict:
     def test_query_raw_rejected_with_frozendict(self, agent):
         from icp_core.errors import ReplicaReject
 
-        result_obj = cbor2.FrozenDict({
+        result_obj = FrozenDict({
             "status": "rejected",
             "reject_code": 5,
             "reject_message": "canister trapped",
@@ -201,9 +206,9 @@ class TestQueryRawAcceptsFrozenDict:
         import asyncio
 
         reply_arg = b"DIDL\x00\x00"
-        result_obj = cbor2.FrozenDict({
+        result_obj = FrozenDict({
             "status": "replied",
-            "reply": cbor2.FrozenDict({"arg": reply_arg}),
+            "reply": FrozenDict({"arg": reply_arg}),
         })
 
         async def _fake_query_async(*args, **kwargs):

--- a/tests/test_certificate.py
+++ b/tests/test_certificate.py
@@ -51,7 +51,9 @@ def _get_ranges_from_parent(cert_dict):
     assert canister_range is not None, "canister_range data must exist"
     
     ranges_raw = cbor2.loads(canister_range)
-    assert isinstance(ranges_raw, list) and len(ranges_raw) >= 1
+    # cbor2 6.x decodes the self-describe-tagged ranges as immutable tuples,
+    # cbor2 5.x as lists; production code (check_delegation) tolerates both.
+    assert isinstance(ranges_raw, (list, tuple)) and len(ranges_raw) >= 1
     lo, hi = ranges_raw[0]
     return bytes(lo), bytes(hi)
 

--- a/tests/test_query_signature_verification.py
+++ b/tests/test_query_signature_verification.py
@@ -19,7 +19,9 @@ from icp_core.errors import (
     TooManySignatures,
     QuerySignatureVerificationFailed,
     SecurityError,
+    TransportError,
 )
+from icp_certificate.certificate import BlstUnavailable
 from icp_identity.identity import Identity
 
 TEST_PRIVKEY_HEX = "833fe62409237b9d62ec77587520911e9a759cec1d19755b7da901b96dca3d42"
@@ -105,12 +107,16 @@ class TestVerifyQueryResponseSignaturesNoArbitraryCap:
             "signatures": [sig] * 101,
         }
         request_id = b"\x00\x01\x02\x03"
+        # Subnet discovery now reads a BLS-verified certificate; stub it out so
+        # this stays an offline unit test that exercises the signature-walking
+        # logic rather than the network/crypto path.
         # The signatures are all garbage, so we still expect a verification
         # failure — but it must be QuerySignatureVerificationFailed (because
         # we walked the whole list), NOT TooManySignatures (which would mean
         # the cap fired before any verification was attempted).
-        with pytest.raises(QuerySignatureVerificationFailed):
-            agent._verify_query_response_signatures(result, request_id, CANISTER_ID)
+        with patch.object(agent, "_get_subnet_by_canister", return_value=(b"\x00" * 29, {})):
+            with pytest.raises(QuerySignatureVerificationFailed):
+                agent._verify_query_response_signatures(result, request_id, CANISTER_ID)
 
 
 class TestQueryRawWithVerifyQuerySignatures:
@@ -191,6 +197,13 @@ class TestRealQueryResponseSignatureVerification:
         assert "signatures" in result and len(result["signatures"]) > 0
         try:
             agent._verify_query_response_signatures(result, request_id, canister_id)
+        except BlstUnavailable:
+            pytest.skip(
+                "Query-signature verification now reads BLS-verified subnet "
+                "certificates; the official 'blst' binding is not installed."
+            )
+        except TransportError as e:
+            pytest.skip("Network unavailable for live subnet/node-key lookup: %s" % e)
         except QuerySignatureVerificationFailed as e:
             pytest.skip(
                 "Real signature verification failed (fixture may be stale or node key lookup failed): %s" % e

--- a/tests/test_security_fixes.py
+++ b/tests/test_security_fixes.py
@@ -1,0 +1,143 @@
+"""
+Regression tests for the security/correctness audit fixes.
+
+1. system_state.time() must return the already-decoded ULEB128 timestamp
+   from Certificate.lookup_time() instead of decoding it a second time
+   (the old code did LEB128.decode_u_bytes(bytes(int)), which allocates a
+   multi-exabyte buffer and raises MemoryError).
+
+2. Query-signature verification must fetch the subnet id and node public
+   keys from BLS-verified certificates (verify_certificate=True). Reading
+   them unverified would let a malicious boundary node supply forged node
+   keys plus a matching forged signature, defeating the feature.
+"""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from icp_agent import system_state
+from icp_agent.agent import Agent
+from icp_agent.client import Client
+from icp_identity.identity import Identity, DelegateIdentity
+
+# Ed25519 test vector (RFC 8032); used only for tests, not a real secret.
+TEST_PRIVKEY_HEX = "833fe62409237b9d62ec77587520911e9a759cec1d19755b7da901b96dca3d42"
+CANISTER_ID = "wcrzb-2qaaa-aaaap-qhpgq-cai"
+# A valid subnet principal (text form) for the node-key lookup test.
+SUBNET_ID = "tdb26-jop6k-aogll-7ltgs-eruif-6kk7m-qpktf-gdiqx-mxtrf-vb5e6-eqe"
+
+
+@pytest.fixture
+def agent():
+    client = Client(url="https://ic0.app")
+    iden = Identity(privkey=TEST_PRIVKEY_HEX)
+    return Agent(iden, client)
+
+
+# ---------------------------------------------------------------------------
+# Fix 1: system_state.time() must not double-decode the timestamp
+# ---------------------------------------------------------------------------
+
+class TestSystemStateTime:
+    def test_time_returns_decoded_int_without_second_decode(self, agent):
+        """time() returns lookup_time()'s int directly (no MemoryError)."""
+        expected_ns = 1_700_000_000_123_456_789  # realistic ns timestamp
+        fake_cert = MagicMock()
+        fake_cert.lookup_time.return_value = expected_ns
+
+        with patch.object(agent, "read_state_raw", return_value=fake_cert):
+            result = system_state.time(agent, CANISTER_ID)
+
+        assert result == expected_ns
+        fake_cert.lookup_time.assert_called_once()
+
+    def test_time_does_not_call_bytes_on_int(self, agent):
+        """A large timestamp must not blow up (regression for MemoryError)."""
+        fake_cert = MagicMock()
+        fake_cert.lookup_time.return_value = 2**63  # huge; bytes(int) would OOM
+        with patch.object(agent, "read_state_raw", return_value=fake_cert):
+            # Must simply return the value, not attempt a giant allocation.
+            assert system_state.time(agent, CANISTER_ID) == 2**63
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: query-signature verification fetches keys from verified certificates
+# ---------------------------------------------------------------------------
+
+class TestQuerySignatureUsesVerifiedCertificates:
+    def test_get_node_public_key_requires_verified_certificate(self, agent):
+        """_get_node_public_key must read subnet state with verify_certificate=True."""
+        captured = {}
+        fake_cert = MagicMock()
+        fake_cert.lookup.return_value = b"\x00" * 44  # any non-None key
+
+        def fake_read_state_subnet_raw(subnet_id, paths, verify_certificate=True):
+            captured["verify_certificate"] = verify_certificate
+            return fake_cert
+
+        subnet_id = Identity(privkey=TEST_PRIVKEY_HEX).sender().bytes
+        node_id = b"\x11" * 28
+
+        with patch.object(agent, "read_state_subnet_raw", side_effect=fake_read_state_subnet_raw):
+            agent._get_node_public_key(subnet_id, node_id)
+
+        assert captured["verify_certificate"] is True, \
+            "node public key must come from a BLS-verified subnet certificate"
+
+    def test_get_subnet_by_canister_requires_verified_certificate(self, agent):
+        """_get_subnet_by_canister must read canister state with verify_certificate=True."""
+        captured = {}
+        fake_cert = MagicMock()
+        fake_cert.delegation = None  # exercise the no-delegation branch
+
+        def fake_read_state_raw(canister_id, paths, verify_certificate=True):
+            captured["verify_certificate"] = verify_certificate
+            return fake_cert
+
+        with patch.object(agent, "read_state_raw", side_effect=fake_read_state_raw):
+            subnet_id, node_keys = agent._get_subnet_by_canister(CANISTER_ID)
+
+        assert captured["verify_certificate"] is True, \
+            "subnet id must be derived from a BLS-verified canister certificate"
+        assert isinstance(subnet_id, bytes)
+
+
+# ---------------------------------------------------------------------------
+# Fix 3: Identity repr/str must not leak the private key
+# ---------------------------------------------------------------------------
+
+class TestIdentityDoesNotLeakPrivateKey:
+    PRIV = "833fe62409237b9d62ec77587520911e9a759cec1d19755b7da901b96dca3d42"
+
+    def test_repr_redacts_private_key(self):
+        iden = Identity(privkey=self.PRIV, type="ed25519")
+        assert self.PRIV not in repr(iden)
+        assert iden.privkey not in repr(iden)
+        # Public material is still useful for debugging.
+        assert iden.pubkey in repr(iden)
+
+    def test_str_redacts_private_key(self):
+        iden = Identity(privkey=self.PRIV, type="ed25519")
+        assert self.PRIV not in str(iden)
+        assert iden.privkey not in str(iden)
+
+    def test_privkey_property_still_works(self):
+        """The redaction must not break the legitimate accessor."""
+        iden = Identity(privkey=self.PRIV, type="ed25519")
+        assert iden.privkey == self.PRIV
+
+    def test_delegate_identity_repr_does_not_leak_inner_key(self):
+        inner = Identity(privkey=self.PRIV, type="ed25519")
+        delegation = {
+            "publicKey": inner.der_pubkey.hex(),
+            "delegations": [
+                {
+                    "delegation": {"expiration": "0x100", "pubkey": inner.der_pubkey.hex()},
+                    "signature": "00" * 64,
+                }
+            ],
+        }
+        deleg = DelegateIdentity(inner, delegation)
+        assert inner.privkey not in repr(deleg)
+        assert inner.privkey not in str(deleg)


### PR DESCRIPTION
## Overview

Audit of all files under `src/` (agent, certificate/BLS verification, identity, principal, candid, DID loader, canister wrappers, errors, Rust parser). This fixes the three issues found and adds regression tests. All 175 tests pass (6 skipped — they require the optional `blst` binding).

## Fixed

### 1. `system_state.time()` was completely broken (MemoryError / DoS)
`Certificate.lookup_time()` already returns a decoded `int`, but `time()` then did `LEB128.decode_u_bytes(bytes(timestamp))`. `bytes(<ns-timestamp>)` allocates a multi-exabyte zero buffer → `MemoryError` (confirmed). Now returns the value directly; removed the now-unused `LEB128` import.

### 2. Query-signature verification trusted unverified certificates (security)
When `verify_query_signatures=True`, the subnet ID and the **node public keys** — the trust anchor for the signature — were fetched via `read_state` with `verify_certificate=False`. A malicious boundary node could supply a forged node key **and** a matching forged signature and pass verification, defeating the entire feature. All four fetch sites (`_get_node_public_key`, `_get_subnet_by_canister`, and their async variants) now use `verify_certificate=True` (fail-closed: raises rather than trusting unverified data).

### 3. Private key leaked in `Identity.__repr__`/`__str__` (secret exposure)
`Identity` (and `DelegateIdentity`) embedded the raw private key in `repr()`/`str()`, so any log line, traceback, or debugger inspecting an identity leaked the secret. The private key is now redacted; the (public) key type and public key are retained. The `.privkey` accessor is unchanged.

### 4. Docstring fix
`extract_ed25519_pubkey_from_der` said node keys are "BLS keys" — corrected to Ed25519 (RFC 8410).

## Tests
- New `tests/test_security_fixes.py` (8 regression tests) covering all three fixes.
- Restored the canister-range **authorization** security test (`test_certificate.py`), previously blocked by an over-strict `isinstance(list)` assertion — cbor2 6.x returns immutable tuples for the self-describe-tagged ranges; production code already tolerates both.
- `test_cbor2_frozendict_compat.py`: resolve `FrozenDict`/`frozendict` across cbor2 versions (src was already correct via the `Mapping` ABC).
- `test_query_signature_verification.py`: live-fixture integration test now skips cleanly when `blst`/network is unavailable; offline unit test mocks subnet lookup.

## Audited and confirmed correct (no change)
Ed25519 signing (verified byte-identical to PyNaCl / RFC 8032), the BLS certificate verification + delegation chain + sharded canister-range check + timestamp-skew check, principal checksum/round-trip and self-authenticating derivation, Candid encode/decode + LEB128 + request-id (RIH) hashing, the HTTP client, the error hierarchy, and the Rust DID parser.

## Reviewer notes
- The optional `blst` binding is not installed in this environment, so the actual BLS verification path (6 skipped tests) was not executed end-to-end. Fix #2 is validated at the "passes `verify_certificate=True`" level via unit tests.
- Residual (left as-is): `Canister._fetch_candid_from_ic` fetches candid **metadata** with verification disabled. Low risk (Candid field hashing is name-based and the real canister validates its own interface, so a forged interface yields encode/decode errors, not unauthorized actions); it's opt-in (`auto_fetch_candid=False` by default) and verifying it would require `blst`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)